### PR TITLE
add queue to ruleset

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -32,4 +32,4 @@ jobs:
         push: true
         tags: |
           ghcr.io/sekoia-io/sekoiaio-docker-concentrator:latest
-          ghcr.io/sekoia-io/sekoiaio-docker-concentrator:2.2
+          ghcr.io/sekoia-io/sekoiaio-docker-concentrator:2.3

--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -32,4 +32,4 @@ jobs:
         push: true
         tags: |
           ghcr.io/sekoia-io/sekoiaio-docker-concentrator:latest
-          ghcr.io/sekoia-io/sekoiaio-docker-concentrator:2.1
+          ghcr.io/sekoia-io/sekoiaio-docker-concentrator:2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes with sekoiaio concentrator will be documented in this file.
+## [2.2]
+
+- Improve performances for multiple ruleset configuration (ref: https://www.rsyslog.com/doc/concepts/multi_ruleset.html#rulesets-and-queues)
 
 ## [2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
 All notable changes with sekoiaio concentrator will be documented in this file.
-## [2.2]
+
+## [2.3]
 
 - Improve performances for multiple ruleset configuration (ref: https://www.rsyslog.com/doc/concepts/multi_ruleset.html#rulesets-and-queues)
+
+## [2.2]
+
+- Update main queue settings
 
 ## [2.1]
 

--- a/template.j2
+++ b/template.j2
@@ -5,8 +5,9 @@ template(name="SEKOIAIO_{{ name |lower }}_Input_Template" type="string" string="
 template(name="SEKOIAIO_{{ name |lower }}_Output_Template" type="string" string="[Output \"{{ intake_key }}\"] <%pri%>1 %timegenerated:::date-rfc3339% %hostname% %app-name% %procid% LOG [SEKOIA@53288 intake_key=\"{{ intake_key }}\"] %msg:R,ERE,1,FIELD:^[ \t]*(.*)$--end%\n")
 {% endif %}
 template(name="SEKOIAIO_{{ name |lower }}_Template" type="string" string="<%pri%>1 %timegenerated:::date-rfc3339% %hostname% %app-name% %procid% LOG [SEKOIA@53288 intake_key=\"{{ intake_key }}\"] %msg:R,ERE,1,FIELD:^[ \t]*(.*)$--end%\n")
-ruleset(name="remote{{ port }}"){
+ruleset(name="remote{{ port }}" queue.type="LinkedList" queue.filename="sekoia_{{ name |lower }}_queue" queue.saveOnShutdown="on"){
 action(
+    name="action{{ name |lower }}"
     type="omfwd"
     protocol="tcp"
     target="intake.sekoia.io"


### PR DESCRIPTION
Rsyslog doc has just been updated 🤣 I think [This new page](https://www.rsyslog.com/doc/concepts/multi_ruleset.html#) explains our problem and what I've done previously. See "Rulesets and Queues" section

I've just added a specific memory queue (no disk-assisted) per ruleset without specific settings (default max size 50000 messages in memory per ruleset). It should improve performances for a high throuput. I've not deactivate throlling option as I've done in the "debug" branch (ref: https://www.rsyslog.com/doc/concepts/queues.html#filled-up-queues) because in debug logs I've not seen a queue full or nearly full. 