### PR TITLE
update Dockerfile to build under arm or amd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:22.04
+# syntax=docker/dockerfile:1.4
+FROM --platform=${TARGETPLATFORM:-linux/amd64}  ubuntu:22.04
+
+ARG TARGETPLATFORM
 
 RUN apt-get update && apt-get install -y \
     rsyslog \


### PR DESCRIPTION
Following client request to run Forwarder under arm architecture
Update the Dockerfile to support multi platform build.

To build for arm, cmd are: 
docker buildx create --use
docker buildx build --platform linux/arm64 -t mysekoiaarm . --load

