### PR TITLE
fix(rsyslog): add resume parameter to resent logs when connectivity r…

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -37,4 +37,4 @@ jobs:
         push: true
         tags: |
           ghcr.io/sekoia-io/sekoiaio-docker-concentrator:latest
-          ghcr.io/sekoia-io/sekoiaio-docker-concentrator:2.7.4
+          ghcr.io/sekoia-io/sekoiaio-docker-concentrator:2.7.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes with sekoiaio concentrator will be documented in this file.
 
+## [2.7.5]
+
+- Add `action.resumeRetryCount=-1` and `action.resumeInterval=30` to all output actions:
+  - Fixes issue where rsyslog would suspend forwarding actions after network outages
+  - Ensures queued logs are reliably resent when connectivity is restored
+  - Prevents data loss during temporary network interruptions
+  - Applies to TCP, RELP, and stats monitoring output actions in all templates (template.j2, template_tls.j2, stats_template.j2)
+
 ## [2.7.4]
 
 - Update default regional intake endpoint

--- a/stats_template.j2
+++ b/stats_template.j2
@@ -12,5 +12,7 @@ action(
     StreamDriverAuthMode="x509/name"
     StreamDriverPermittedPeers="{{ endpoint }}"
     Template="SEKOIAIO_stats_Template"
+    action.resumeRetryCount="-1"
+    action.resumeInterval="10"
     )
 }

--- a/template.j2
+++ b/template.j2
@@ -16,6 +16,8 @@ action(
     tls.authmode="name"
     tls.permittedpeer="{{ ('relp.' ~ endpoint) if endpoint.startswith("intake") else endpoint }}"
     Template="SEKOIAIO_{{ name |lower }}_Template"
+    action.resumeRetryCount="-1"
+    action.resumeInterval="30"
     )
 {% else %}
 action(
@@ -30,6 +32,8 @@ action(
     StreamDriverAuthMode="x509/name"
     StreamDriverPermittedPeers="{{ endpoint }}"
     Template="SEKOIAIO_{{ name | lower }}_Template"
+    action.resumeRetryCount="-1"
+    action.resumeInterval="30"
     )
 {% endif %}
 {% if ( debug | lower ) == "true"  %}

--- a/template_tls.j2
+++ b/template_tls.j2
@@ -28,6 +28,8 @@ action(
     tls.authmode="name"
     tls.permittedpeer="{{ ('relp.' ~ endpoint) if endpoint.startswith("intake") else endpoint }}"
     Template="SEKOIAIO_{{ name |lower }}_Template"
+    action.resumeRetryCount="-1"
+    action.resumeInterval="30"
     )
 {% else %}
 action(
@@ -42,6 +44,8 @@ action(
     StreamDriverAuthMode="x509/name"
     StreamDriverPermittedPeers="{{ endpoint }}"
     Template="SEKOIAIO_{{ name |lower }}_Template"
+    action.resumeRetryCount="-1"
+    action.resumeInterval="30"
     )
 {% endif %}
 {% if ( debug | lower ) == "true"  %}


### PR DESCRIPTION
- Add resume parameter to resent logs when connectivity restored.

- PR created from this issue https://github.com/SekoiaLab/platform/issues/82883. Needs permissions on the repo to see it

- Used the guide below to test this fix and works like a charm

# Local Testing Guide - Network Outage Fix

This guide will help you reproduce and test the network outage issue fix on your local machine.

## Prerequisites

- Docker and Docker Compose installed
- Root/sudo access (for iptables commands)
- `netcat` (nc) installed for sending test logs
- Valid Sekoia.io intake key for testing

## Important: Docker Networking & iptables

**Docker containers bypass the standard OUTPUT iptables chain.** Container traffic goes through:
- `DOCKER-USER` chain - Custom rules for Docker
- `FORWARD` chain - Forwarded/routed traffic

This means standard iptables rules like `iptables -A OUTPUT -d host -j DROP` will NOT block Docker container traffic.

**Always use these chains for Docker:**
```bash
sudo iptables -I DOCKER-USER -d <IP> -j DROP
sudo iptables -I FORWARD -d <IP> -j DROP
```

This guide includes the correct commands for blocking Docker container network access.

## Quick Reference - Block/Unblock Network

**Block Sekoia intake (for testing):**
```bash
INTAKE_IP=$(dig +short intake.sekoia.io | head -1)
sudo iptables -I DOCKER-USER -d $INTAKE_IP -j DROP
sudo iptables -I FORWARD -d $INTAKE_IP -j DROP
```

**Restore network:**
```bash
INTAKE_IP=$(dig +short intake.sekoia.io | head -1)
sudo iptables -D DOCKER-USER -d $INTAKE_IP -j DROP
sudo iptables -D FORWARD -d $INTAKE_IP -j DROP
```

**Send test messages:**
```bash
# Single message (use -q 0 to avoid hanging)
echo "<14>Test message" | nc -q 0 localhost 20516

# Multiple messages
for i in {1..10}; do
  echo "<14>Test message $i" | nc -q 0 localhost 20516
  sleep 1
done
```

---

## Step 1: Build the Docker Image Locally

Since the fix hasn't been published to the registry yet, build the image locally:

```bash
# Navigate to the project directory
cd /home/hostname/Documents/workspace/sekoiaio-docker-concentrator

# Build the Docker image with the fix
docker build -t sekoiaio-docker-concentrator:2.7.5-local .

# Verify the image was created
docker images | grep sekoiaio-docker-concentrator
```

## Step 2: Prepare Test Environment

### 2.1 Create Test Directory

```bash
# Create a test directory
mkdir -p ~/sekoia-test
cd ~/sekoia-test

# Copy necessary files
cp /home/hostname/Documents/workspace/sekoiaio-docker-concentrator/docker-compose/intakes.yaml .
cp /home/hostname/Documents/workspace/sekoiaio-docker-concentrator/docker-compose/docker-compose.yml .

# IMPORTANT: Update docker-compose.yml to use local image NOW
sed -i 's|image: ghcr.io/sekoia-io/sekoiaio-docker-concentrator:.*|image: sekoiaio-docker-concentrator:2.7.5-local|' docker-compose.yml
sed -i '/pull_policy:/d' docker-compose.yml

# Create disk queue directory
mkdir -p disk_queue
```

### 2.2 Configure intakes.yaml

Edit `intakes.yaml` with a test intake:

```yaml
---
intakes:
- name: TestIntake
  protocol: tcp
  port: 20516
  intake_key: YOUR_REAL_INTAKE_KEY_HERE  # Use a valid intake key
  debug: true  # Enable debug mode to see logs
```

### 2.3 Modify docker-compose.yml

**CRITICAL:** Update the image reference to use your local build:

**Option A - Quick Fix (sed command):**
```bash
# Automatically update the docker-compose.yml
sed -i 's|image: ghcr.io/sekoia-io/sekoiaio-docker-concentrator:.*|image: sekoiaio-docker-concentrator:2.7.5-local|' docker-compose.yml
sed -i '/pull_policy:/d' docker-compose.yml
```

**Option B - Manual Edit:**
Edit `docker-compose.yml` and change these lines:

```yaml
# Version is deprecated with latest versions of Docker Engine
# version: "3.9"
services:
  rsyslog:
    image: sekoiaio-docker-concentrator:2.7.5-local  # Use local image (NO ghcr.io prefix!)
    environment:
      - MEMORY_MESSAGES=2000000
      - DISK_SPACE=180g
      - REGION=FRA1
    ports:
      - "20516:20516"
      - "20516:20516/udp"
    volumes:
      - ./intakes.yaml:/intakes.yaml
      - ./disk_queue:/var/spool/rsyslog
    restart: always
    # Remove or comment out pull_policy line
```

**Verify the changes:**
```bash
grep "image:" docker-compose.yml
# Should output: image: sekoiaio-docker-concentrator:2.7.5-local
```

## Step 3: Start the Forwarder

```bash
cd ~/sekoia-test

# Start the container
docker compose up -d

# Check it's running
docker compose ps

# View logs to verify configuration
docker compose logs
```

You should see output like:
```
These Intakes have been set up
-----------------------------
Intake name: TestIntake
Protocol: tcp
Port: 20516
Intake key: YOUR_INTAKE_KEY
Queue size: 2000000
```

## Step 4: Verify the Fix is Applied

```bash
# Check that resumeRetryCount is configured (ignore errors for missing system files)
docker compose exec rsyslog sh -c 'cat /etc/rsyslog.d/[0-9]*.conf 2>/dev/null | grep -A2 "resumeRetryCount"'
```

Expected output:
```
action.resumeRetryCount="-1"
action.resumeInterval="30"
```

**Alternative verification (shows the full action configuration):**
```bash
# List the generated intake config files
docker compose exec rsyslog ls -la /etc/rsyslog.d/

# View a specific intake config (adjust filename as needed)
docker compose exec rsyslog cat /etc/rsyslog.d/1_testintake.conf
```

## Step 5: Test Normal Operation

```bash
# Send a test message
echo "<14>Test message before network outage" | nc -q 0 localhost 20516

# Check logs - you should see the message being forwarded
docker compose logs --tail=30
```

Look for debug output (if enabled):
```
[Input "YOUR_INTAKE_KEY"] <14>Test message before network outage
[Output "YOUR_INTAKE_KEY"] <14>1 2026-05-21T... ... LOG [SEKOIA@53288 intake_key="..."] Test message before network outage
```

## Step 6: Simulate Network Outage

### 6.1 Block Sekoia Intake

**IMPORTANT:** Docker containers bypass the OUTPUT chain and use DOCKER-USER/FORWARD chains.

```bash
# Get the Sekoia intake IP address
INTAKE_IP=$(dig +short intake.sekoia.io | head -1)
echo "Sekoia intake IP: $INTAKE_IP"

# For other regions:
# INTAKE_IP=$(dig +short intake.fra2.sekoia.io | head -1)
# INTAKE_IP=$(dig +short intake.mco1.sekoia.io | head -1)

# Block Docker container traffic to Sekoia intake
# Must use DOCKER-USER and FORWARD chains (containers bypass OUTPUT)
sudo iptables -I DOCKER-USER -d $INTAKE_IP -j DROP
sudo iptables -I FORWARD -d $INTAKE_IP -j DROP

# Verify the rules are in place
echo "Verification:"
sudo iptables -L DOCKER-USER -n -v | grep $INTAKE_IP
sudo iptables -L FORWARD -n -v | head -5 | grep DROP
```

**Alternative: Use the helper script**

```bash
# Create a reusable block/unblock script
cat > ~/sekoia-test/block-sekoia.sh << 'EOF'
#!/bin/bash
INTAKE_IP=$(dig +short intake.sekoia.io | head -1)
echo "Blocking $INTAKE_IP"
sudo iptables -I DOCKER-USER -d $INTAKE_IP -j DROP
sudo iptables -I FORWARD -d $INTAKE_IP -j DROP
echo "✓ Network blocked"
EOF

cat > ~/sekoia-test/unblock-sekoia.sh << 'EOF'
#!/bin/bash
INTAKE_IP=$(dig +short intake.sekoia.io | head -1)
echo "Unblocking $INTAKE_IP"
sudo iptables -D DOCKER-USER -d $INTAKE_IP -j DROP 2>/dev/null
sudo iptables -D FORWARD -d $INTAKE_IP -j DROP 2>/dev/null
echo "✓ Network restored"
EOF

chmod +x ~/sekoia-test/*.sh

# Use it:
~/sekoia-test/block-sekoia.sh
```

### 6.2 Send Logs During Outage

```bash
# Send multiple test messages
for i in {1..10}; do
  echo "<14>Test message during outage $i - $(date +%s)" | nc -q 0 localhost 20516
  sleep 1
done
```

### 6.3 Observe Behavior During Outage

```bash
# Monitor logs in real-time
docker compose logs -f --tail=50
```

You should see:
- Messages being received (Input debug lines)
- Connection errors when trying to send to Sekoia
- **Retry attempts every 10 seconds** ← This is the fix in action
- **NO "action suspended" messages** ← This confirms the fix

```bash
# In another terminal, monitor disk queue
watch -n 2 'ls -lh ~/sekoia-test/disk_queue/ && du -sh ~/sekoia-test/disk_queue/'
```

You should see queue files being created and growing:
```
sekoia_testintake_queue.00000001
```

## Step 7: Restore Network Connectivity

```bash
# Get the Sekoia intake IP (same as used in Step 6)
INTAKE_IP=$(dig +short intake.sekoia.io | head -1)

# Remove the iptables rules from Docker chains
sudo iptables -D DOCKER-USER -d $INTAKE_IP -j DROP
sudo iptables -D FORWARD -d $INTAKE_IP -j DROP

echo "Network restored for $INTAKE_IP"

# Or use the helper script:
# ~/sekoia-test/unblock-sekoia.sh
```

## Step 8: Verify Automatic Recovery

```bash
# Continue monitoring logs
docker compose logs -f --tail=100
```

**Expected behavior (WITH the fix - v2.7.5):**
- Within 10-30 seconds, you should see successful connections
- Queue files being processed
- Messages being forwarded to Sekoia
- Disk queue files shrinking/disappearing

```bash
# Monitor disk queue drainage
watch -n 2 'ls -lh ~/sekoia-test/disk_queue/ && du -sh ~/sekoia-test/disk_queue/'
```

The queue directory should become empty or contain only checkpoint files.

### 8.1 Verify in Sekoia.io

Log into your Sekoia.io account and verify that all 10+ test messages appear in the events (including those sent during the outage).

## Step 9: Test WITHOUT the Fix (Optional - for comparison)

To see the difference, you can test with the old configuration:

### 9.1 Revert the Fix Temporarily

```bash
cd /home/hostname/Documents/workspace/sekoiaio-docker-concentrator

# Create backup of fixed templates
cp template.j2 template.j2.fixed
cp template_tls.j2 template_tls.j2.fixed

# Remove the fix parameters from templates
sed -i '/action.resumeRetryCount/d' template.j2
sed -i '/action.resumeInterval/d' template.j2
sed -i '/action.resumeRetryCount/d' template_tls.j2
sed -i '/action.resumeInterval/d' template_tls.j2

# Rebuild the image
docker build -t sekoiaio-docker-concentrator:2.7.4-broken .
```

### 9.2 Update docker-compose.yml

```yaml
image: sekoiaio-docker-concentrator:2.7.4-broken
```

### 9.3 Restart and Repeat Test

```bash
cd ~/sekoia-test
docker compose down
rm -rf disk_queue/*
docker compose up -d

# Repeat steps 6-8
```

**Expected behavior (WITHOUT the fix - v2.7.4):**
- Queue files created during outage
- After network restoration: **logs are NOT resent**
- Queue files remain in disk_queue/
- You may see "action suspended" messages
- Messages lost until manual restart: `docker compose restart`

### 9.4 Restore the Fix

```bash
cd /home/hostname/Documents/workspace/sekoiaio-docker-concentrator

# Restore fixed templates
cp template.j2.fixed template.j2
cp template_tls.j2.fixed template_tls.j2

# Rebuild
docker build -t sekoiaio-docker-concentrator:2.7.5-local .
```

## Complete Test Script

Here's an automated test script you can use:

```bash
#!/bin/bash
# save as: ~/sekoia-test/test-network-outage.sh
# chmod +x ~/sekoia-test/test-network-outage.sh

set -e

INTAKE_ENDPOINT="intake.sekoia.io"
CONTAINER_NAME="sekoia-test-rsyslog-1"
TEST_PORT=20516

echo "=== Sekoia Forwarder Network Outage Test ==="
echo ""

echo "Step 1: Verify container is running..."
docker compose ps | grep rsyslog || { echo "Container not running!"; exit 1; }

echo "Step 2: Send test message (normal operation)..."
echo "<14>PRE-OUTAGE: Test message before outage $(date +%s)" | nc -q 0 localhost $TEST_PORT
sleep 2

echo "Step 3: Check initial disk queue..."
QUEUE_SIZE_BEFORE=$(du -s disk_queue/ 2>/dev/null | cut -f1)
echo "Queue size before: ${QUEUE_SIZE_BEFORE:-0} KB"

echo "Step 4: Simulate network outage..."
INTAKE_IP=$(dig +short $INTAKE_ENDPOINT | head -1)
echo "Blocking $INTAKE_IP ($INTAKE_ENDPOINT)"
# Use DOCKER-USER and FORWARD chains for container traffic
sudo iptables -I DOCKER-USER -d $INTAKE_IP -j DROP 2>/dev/null
sudo iptables -I FORWARD -d $INTAKE_IP -j DROP 2>/dev/null
echo "Network blocked for $INTAKE_ENDPOINT ($INTAKE_IP)"

echo "Step 5: Send messages during outage..."
for i in {1..5}; do
  echo "<14>DURING-OUTAGE: Message $i during outage $(date +%s)" | nc -q 0 localhost $TEST_PORT
  echo "  Sent message $i"
  sleep 1
done

echo "Step 6: Wait 30 seconds and check queue growth..."
sleep 30
QUEUE_SIZE_DURING=$(du -s disk_queue/ 2>/dev/null | cut -f1)
echo "Queue size during outage: ${QUEUE_SIZE_DURING:-0} KB"

if [ ${QUEUE_SIZE_DURING:-0} -le ${QUEUE_SIZE_BEFORE:-0} ]; then
  echo "WARNING: Queue did not grow during outage!"
fi

echo "Step 7: Check for retry attempts in logs..."
docker compose logs --tail=50 | grep -i "error\|retry" | tail -5

echo "Step 8: Restore network connectivity..."
INTAKE_IP=$(dig +short $INTAKE_ENDPOINT | head -1)
sudo iptables -D DOCKER-USER -d $INTAKE_IP -j DROP 2>/dev/null
sudo iptables -D FORWARD -d $INTAKE_IP -j DROP 2>/dev/null
echo "Network restored for $INTAKE_ENDPOINT ($INTAKE_IP)"

echo "Step 9: Wait for automatic recovery (60 seconds)..."
for i in {60..1}; do
  echo -ne "  Waiting... $i seconds remaining\r"
  sleep 1
done
echo ""

echo "Step 10: Check queue after recovery..."
QUEUE_SIZE_AFTER=$(du -s disk_queue/ 2>/dev/null | cut -f1)
echo "Queue size after recovery: ${QUEUE_SIZE_AFTER:-0} KB"

echo "Step 11: Recent logs..."
docker compose logs --tail=30

echo ""
echo "=== Test Results ==="
echo "Queue size before:  ${QUEUE_SIZE_BEFORE:-0} KB"
echo "Queue size during:  ${QUEUE_SIZE_DURING:-0} KB"
echo "Queue size after:   ${QUEUE_SIZE_AFTER:-0} KB"
echo ""

if [ ${QUEUE_SIZE_AFTER:-0} -lt ${QUEUE_SIZE_DURING:-0} ]; then
  echo "✅ SUCCESS: Queue drained after recovery!"
  echo "   The fix is working correctly."
else
  echo "❌ FAILURE: Queue did not drain after recovery!"
  echo "   Logs may not have been resent automatically."
fi

echo ""
echo "Check your Sekoia.io interface to verify all messages were received."
```

Run the test:
```bash
cd ~/sekoia-test
chmod +x test-network-outage.sh
./test-network-outage.sh
```

## Cleanup

```bash
# Stop and remove containers
cd ~/sekoia-test
docker compose down

# Remove test data
rm -rf ~/sekoia-test

# Remove iptables rules (if still present)
INTAKE_IP=$(dig +short intake.sekoia.io | head -1 2>/dev/null)
if [ -n "$INTAKE_IP" ]; then
  sudo iptables -D DOCKER-USER -d $INTAKE_IP -j DROP 2>/dev/null || true
  sudo iptables -D FORWARD -d $INTAKE_IP -j DROP 2>/dev/null || true
fi
```

## Troubleshooting

### Error: "manifest unknown" or "image not found"

**Error message:**
```
✘ Image ghcr.io/sekoia-io/sekoiaio-docker-concentrator:2.7.5-local Error manifest unknown
```

**Cause:** The docker-compose.yml is still trying to pull from the registry instead of using your local image.

**Solution:**
```bash
cd ~/sekoia-test

# Fix the image reference
sed -i 's|image: ghcr.io/sekoia-io/sekoiaio-docker-concentrator:.*|image: sekoiaio-docker-concentrator:2.7.5-local|' docker-compose.yml

# Remove pull_policy line
sed -i '/pull_policy:/d' docker-compose.yml

# Verify the fix
cat docker-compose.yml | grep -A1 "image:"

# Should show:
#   image: sekoiaio-docker-concentrator:2.7.5-local

# Now try again
docker compose up -d
```

### Container fails to start

```bash
# Check logs for errors
docker compose logs

# Common issues:
# - Invalid intake key format (must be 16+ alphanumeric)
# - Port already in use (check with: sudo netstat -tlnp | grep 20516)
# - Permission issues with disk_queue/ (fix: sudo chown -R 104:108 disk_queue/)
```

### Cannot send logs with netcat

```bash
# Install netcat if missing
sudo apt-get install netcat  # Ubuntu/Debian
sudo yum install nc          # CentOS/RHEL

# Test netcat
echo "test" | nc -q 0 localhost 20516
echo $?  # Should return 0 if successful
```

**If netcat hangs and doesn't return to prompt:**

OpenBSD netcat (most common on Ubuntu/Debian) needs the `-q` flag:
```bash
# -q 0 = quit immediately after EOF (recommended)
echo "message" | nc -q 0 localhost 20516

# Alternative: -w 1 = timeout after 1 second
echo "message" | nc -w 1 localhost 20516
```

For GNU netcat (ncat), use `-C` to close connection:
```bash
echo "message" | nc -C localhost 20516
```

**Check your netcat version:**
```bash
nc -h 2>&1 | head -1
# OpenBSD netcat: use -q 0
# GNU netcat/ncat: use -C
```

### iptables rule doesn't work / Traffic still reaches Sekoia

**Problem:** Docker containers bypass the OUTPUT chain.

**Solution:** Use DOCKER-USER and FORWARD chains:

```bash
# Get the IP address
INTAKE_IP=$(dig +short intake.sekoia.io | head -1)
echo "Sekoia IP: $INTAKE_IP"

# Remove any incorrect OUTPUT rules
sudo iptables -D OUTPUT -d intake.sekoia.io -j DROP 2>/dev/null
sudo iptables -D OUTPUT -d $INTAKE_IP -j DROP 2>/dev/null

# Add rules to the correct chains for Docker
sudo iptables -I DOCKER-USER -d $INTAKE_IP -j DROP
sudo iptables -I FORWARD -d $INTAKE_IP -j DROP

# Verify rules are active
echo "\nDOCKER-USER chain:"
sudo iptables -L DOCKER-USER -n -v | grep $INTAKE_IP
echo "\nFORWARD chain:"
sudo iptables -L FORWARD -n -v | head -5 | grep DROP

# Test from within the container
docker compose exec rsyslog ping -c 1 $INTAKE_IP
# Should show: "ping: sendto: Operation not permitted" or timeout
```

### Debug mode not showing messages

Ensure `debug: true` is set in intakes.yaml and restart:
```bash
docker compose down
docker compose up -d
docker compose logs -f
```

## Expected Timeline

| Phase | Duration | Expected Behavior |
|-------|----------|-------------------|
| Normal operation | Instant | Logs forwarded immediately |
| Network blocked | 0-10s | First retry attempt fails |
| Queue building | 10-60s | Retry every 10s, queue grows |
| Network restored | 0-30s | Automatic reconnection |
| Queue draining | 30-120s | All queued logs sent |

## Key Indicators of Success

✅ **During outage:**
- Disk queue files created and growing
- Logs show retry attempts every ~10 seconds
- NO "action suspended" messages

✅ **After recovery:**
- Logs show successful connections
- Disk queue files processed and removed
- All messages visible in Sekoia.io (including outage period)
- No manual restart required

## Notes

- The `action.resumeInterval="10"` means retries happen every 10 seconds
- Real-world network outages may last minutes to hours
- Ensure your `DISK_SPACE` setting is adequate for expected outage duration
- Monitor disk queue size in production environments
- All test messages should appear in Sekoia.io with correct timestamps
