### PR TITLE
fix(sekoia-docker-concentrator): use rawmsg-after-pri instead of msg …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes with sekoiaio concentrator will be documented in this file.
 
+## [2.7.6]
+
+- Preserve the original message payload when forwarding events to Sekoia:
+  - Replace `%msg%` with `%rawmsg-after-pri%` in `template.j2` and `template_tls.j2`
+  - Fixes loss of the `CEF:0` banner (and other content stripped by rsyslog's RFC 3164 parser when a leading token ends with `:`, e.g. Forcepoint NGFW, ArcSight CEF sources)
+  - The outbound payload now contains the exact bytes received from the source after the syslog `<PRI>`, instead of rsyslog's reparsed `%msg%`
+
 ## [2.7.5]
 
 - Add `action.resumeRetryCount=-1` and `action.resumeInterval=30` to all output actions:

--- a/template.j2
+++ b/template.j2
@@ -2,9 +2,9 @@ input(type="im{{ protocol | lower }}" port="{{ port }}" ruleset="ruleset-{{ name
 
 {% if debug %}
 template(name="SEKOIAIO_{{ name |lower }}_Input_Template" type="string" string="[Input \"{{ intake_key }}\"] %rawmsg%\n")
-template(name="SEKOIAIO_{{ name |lower }}_Output_Template" type="string" string="[Output \"{{ intake_key }}\"] <%pri%>1 %timegenerated:::date-rfc3339% %hostname% %app-name% %procid% LOG [SEKOIA@53288 intake_key=\"{{ intake_key }}\"] %msg:R,ERE,1,FIELD:^[ \t]*(.*)$--end%\n")
+template(name="SEKOIAIO_{{ name |lower }}_Output_Template" type="string" string="[Output \"{{ intake_key }}\"] <%pri%>1 %timegenerated:::date-rfc3339% %hostname% %app-name% %procid% LOG [SEKOIA@53288 intake_key=\"{{ intake_key }}\"] %rawmsg-after-pri:R,ERE,1,FIELD:^[ \t]*(.*)$--end%\n")
 {% endif %}
-template(name="SEKOIAIO_{{ name |lower }}_Template" type="string" string="<%pri%>1 %timegenerated:::date-rfc3339% %hostname% %app-name% %procid% LOG [SEKOIA@53288 intake_key=\"{{ intake_key }}\"] %msg:R,ERE,1,FIELD:^[ \t]*(.*)$--end%\n")
+template(name="SEKOIAIO_{{ name |lower }}_Template" type="string" string="<%pri%>1 %timegenerated:::date-rfc3339% %hostname% %app-name% %procid% LOG [SEKOIA@53288 intake_key=\"{{ intake_key }}\"] %rawmsg-after-pri:R,ERE,1,FIELD:^[ \t]*(.*)$--end%\n")
 ruleset(name="ruleset-{{ name | lower}}" queue.type="LinkedList" queue.filename="sekoia_{{ name |lower }}_queue" queue.size="{{ queue_size if queue_size else default_queue_size }}" queue.saveOnShutdown="on") {
 {% if env['RELP_OUTPUT'] %}
 action(

--- a/template_tls.j2
+++ b/template_tls.j2
@@ -11,11 +11,11 @@ input(type="imtcp"
 
 {% if debug %}
 template(name="SEKOIAIO_{{ name |lower }}_Input_Template" type="string" string="[Input \"{{ intake_key }}\"] %rawmsg%\n")
-template(name="SEKOIAIO_{{ name |lower }}_Output_Template" type="string" string="[Output \"{{ intake_key }}\"] <%pri%>1 %timegenerated:::date-rfc3339% %hostname% %app-name% %procid% LOG [SEKOIA@53288 intake_key=\"{{ intake_key }}\"] %msg:R,ERE,1,FIELD:^[ \t]*(.*)$--end%\n")
+template(name="SEKOIAIO_{{ name |lower }}_Output_Template" type="string" string="[Output \"{{ intake_key }}\"] <%pri%>1 %timegenerated:::date-rfc3339% %hostname% %app-name% %procid% LOG [SEKOIA@53288 intake_key=\"{{ intake_key }}\"] %rawmsg-after-pri:R,ERE,1,FIELD:^[ \t]*(.*)$--end%\n")
 {% endif %}
 
 
-template(name="SEKOIAIO_{{ name |lower }}_Template" type="string" string="<%pri%>1 %timegenerated:::date-rfc3339% %hostname% %app-name% %procid% LOG [SEKOIA@53288 intake_key=\"{{ intake_key }}\"] %msg:R,ERE,1,FIELD:^[ \t]*(.*)$--end%\n")
+template(name="SEKOIAIO_{{ name |lower }}_Template" type="string" string="<%pri%>1 %timegenerated:::date-rfc3339% %hostname% %app-name% %procid% LOG [SEKOIA@53288 intake_key=\"{{ intake_key }}\"] %rawmsg-after-pri:R,ERE,1,FIELD:^[ \t]*(.*)$--end%\n")
 ruleset(name="ruleset-{{ name | lower}}" queue.type="LinkedList" queue.filename="sekoia_{{ name |lower }}_queue" queue.size="{{ queue_size if queue_size else default_queue_size }}" queue.saveOnShutdown="on") {
 
 {% if env['RELP_OUTPUT'] %}


### PR DESCRIPTION
Root cause — rsyslog's default RFC 3164 parser treats a token ending in : as the syslog TAG/programname. So `<6>CEF:0|Forcepoint|...` is parsed as:
- syslogtag = CEF:
- %msg% = 0|Forcepoint|Firewall|...


Since the outbound templates emitted `%msg%`, the `CEF:0|` banner was dropped — which exactly matches the broken event the customer pasted (`0|Forcepoint|Firewall|...`). The same problem would affect any source whose first whitespace-delimited token ends with : (CEF, LEEF, vendor mini-headers, etc.).

Fix — switched the `SEKOIAIO_*_Template` (and the debug Output template) in template.j2 and template_tls.j2 from `%msg%` to `%rawmsg-after-pri%`. This is the canonical rsyslog property for "the full original payload after <PRI> has been removed", so the CEF:0|... banner — and any other prefix the parser would otherwise consume — is preserved verbatim. The `:R,ERE,1,FIELD:^[ \t]*(.*)$--end%` regex extractor is kept to trim any leading whitespace, so behavior for clean, parseable RFC 3164 messages is unchanged in practice.

For Sekoians, the issue associated https://github.com/SekoiaLab/platform/issues/88144