### PR TITLE
feat(helm): initial Helm chart for Kubernetes deployment

### DIFF
--- a/charts/sekoiaio-docker-concentrator/.helmignore
+++ b/charts/sekoiaio-docker-concentrator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/sekoiaio-docker-concentrator/Chart.yaml
+++ b/charts/sekoiaio-docker-concentrator/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: sekoiaio-docker-concentrator
+description: Run a Rsyslog as a concentrator to forward events to Sekoia.io.
+type: application
+version: 0.1.0
+appVersion: "2.7.3"

--- a/charts/sekoiaio-docker-concentrator/templates/_helpers.tpl
+++ b/charts/sekoiaio-docker-concentrator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "sekoiaio-docker-concentrator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "sekoiaio-docker-concentrator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sekoiaio-docker-concentrator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "sekoiaio-docker-concentrator.labels" -}}
+helm.sh/chart: {{ include "sekoiaio-docker-concentrator.chart" . }}
+{{ include "sekoiaio-docker-concentrator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "sekoiaio-docker-concentrator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sekoiaio-docker-concentrator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sekoiaio-docker-concentrator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sekoiaio-docker-concentrator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/sekoiaio-docker-concentrator/templates/configmap.yaml
+++ b/charts/sekoiaio-docker-concentrator/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sekoiaio-docker-concentrator.fullname" . }}-intakes
+  labels:
+    {{- include "sekoiaio-docker-concentrator.labels" . | nindent 4 }}
+data:
+  intakes.yaml: |
+{{ toYaml (dict "intakes" .Values.intakes) | indent 4 }}

--- a/charts/sekoiaio-docker-concentrator/templates/ingress.yaml
+++ b/charts/sekoiaio-docker-concentrator/templates/ingress.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.ingressRoute.enabled }}
+{{- $traefikV3 := .Capabilities.APIVersions.Has "traefik.io/v1alpha1" }}
+{{- $traefikV2 := .Capabilities.APIVersions.Has "traefik.containo.us/v1alpha1" }}
+{{- if not (or $traefikV3 $traefikV2) }}
+  {{- fail "ingressRoute.enabled is true but the Traefik CRD is not available (traefik.io/v1alpha1 or traefik.containo.us/v1alpha1). Install Traefik or pass --api-versions to helm template." }}
+{{- end }}
+{{- $apiVersion := "traefik.io/v1alpha1" }}
+{{- if not $traefikV3 }}
+{{- $apiVersion = "traefik.containo.us/v1alpha1" }}
+{{- end }}
+{{- $fullName := include "sekoiaio-docker-concentrator.fullname" . }}
+{{- range .Values.intakes }}
+{{- if not .stats }}
+{{- $name := .name | lower | replace " " "-" }}
+{{- $entrypoint := .entrypoint | default $name }}
+{{- if ne (.protocol | lower) "udp" }}
+---
+apiVersion: {{ $apiVersion }}
+kind: IngressRouteTCP
+metadata:
+  name: {{ $fullName }}-{{ $name }}
+  labels:
+    {{- include "sekoiaio-docker-concentrator.labels" $ | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ $entrypoint }}
+  routes:
+    - match: HostSNI(`*`)
+      services:
+        - name: {{ $fullName }}
+          port: {{ .port }}
+{{- else }}
+---
+apiVersion: {{ $apiVersion }}
+kind: IngressRouteUDP
+metadata:
+  name: {{ $fullName }}-{{ $name }}
+  labels:
+    {{- include "sekoiaio-docker-concentrator.labels" $ | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ $entrypoint }}
+  routes:
+    - services:
+        - name: {{ $fullName }}
+          port: {{ .port }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/sekoiaio-docker-concentrator/templates/service.yaml
+++ b/charts/sekoiaio-docker-concentrator/templates/service.yaml
@@ -1,0 +1,35 @@
+{{- if eq .Values.service.type "NodePort" }}
+  {{- range .Values.intakes }}
+  {{- if not .stats }}
+    {{- if or (lt (int .port) 30000) (gt (int .port) 32767) }}
+      {{- fail (printf "Intake %q: port %d is outside the NodePort range (30000-32767). Use ports in that range or switch to LoadBalancer." .name (int .port)) }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sekoiaio-docker-concentrator.fullname" . }}
+  labels:
+    {{- include "sekoiaio-docker-concentrator.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    {{- range .Values.intakes }}
+    {{- if not .stats }}
+    - name: {{ .name | lower | replace " " "-" }}
+      port: {{ .port }}
+      targetPort: {{ .port }}
+      protocol: {{ if eq (.protocol | lower) "tls" }}TCP{{ else }}{{ .protocol | upper }}{{ end }}
+      {{- if eq $.Values.service.type "NodePort" }}
+      nodePort: {{ .port }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  selector:
+    {{- include "sekoiaio-docker-concentrator.selectorLabels" . | nindent 4 }}

--- a/charts/sekoiaio-docker-concentrator/templates/serviceaccount.yaml
+++ b/charts/sekoiaio-docker-concentrator/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sekoiaio-docker-concentrator.serviceAccountName" . }}
+  labels:
+    {{- include "sekoiaio-docker-concentrator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/sekoiaio-docker-concentrator/templates/statefulset.yaml
+++ b/charts/sekoiaio-docker-concentrator/templates/statefulset.yaml
@@ -42,7 +42,7 @@ spec:
           env:
             - name: DISK_SPACE
               {{- if .Values.persistence.enabled }}
-              value: {{ .Values.persistence.size | quote }}
+              value: {{ .Values.persistence.size | replace "Gi" "g" | quote }}
               {{- else }}
               value: {{ .Values.disk_space | quote }}
               {{- end }}

--- a/charts/sekoiaio-docker-concentrator/templates/statefulset.yaml
+++ b/charts/sekoiaio-docker-concentrator/templates/statefulset.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "sekoiaio-docker-concentrator.fullname" . }}
+  labels:
+    {{- include "sekoiaio-docker-concentrator.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "sekoiaio-docker-concentrator.fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "sekoiaio-docker-concentrator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "sekoiaio-docker-concentrator.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "sekoiaio-docker-concentrator.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: DISK_SPACE
+              {{- if .Values.persistence.enabled }}
+              value: {{ .Values.persistence.size | quote }}
+              {{- else }}
+              value: {{ .Values.disk_space | quote }}
+              {{- end }}
+            - name: MEMORY_MESSAGES
+              value: {{ .Values.memory_messages | quote }}
+            - name: REGION
+              value: {{ .Values.region | quote }}
+            {{- if .Values.endpoint }}
+            - name: ENDPOINT
+              value: {{ .Values.endpoint | quote }}
+            {{- end }}
+            {{- if .Values.relp_output }}
+            - name: RELP_OUTPUT
+              value: "true"
+            {{- end }}
+          ports:
+            {{- range .Values.intakes }}
+            {{- if not .stats }}
+            - name: {{ .name | lower | replace " " "-" }}
+              containerPort: {{ .port }}
+              protocol: {{ if eq (.protocol | lower) "tls" }}TCP{{ else }}{{ .protocol | upper }}{{ end }}
+            {{- end }}
+            {{- end }}
+          volumeMounts:
+            - name: disk-queue
+              mountPath: /var/spool/rsyslog
+            - name: intakes-config
+              mountPath: /intakes.yaml
+              subPath: intakes.yaml
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: intakes-config
+          configMap:
+            name: {{ include "sekoiaio-docker-concentrator.fullname" . }}-intakes
+        {{- if not .Values.persistence.enabled }}
+        - name: disk-queue
+          emptyDir: {}
+        {{- end }}
+{{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: disk-queue
+        {{- with .Values.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.persistence.accessModes | nindent 10 }}
+        {{- with .Values.persistence.storageClass }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/sekoiaio-docker-concentrator/values.yaml
+++ b/charts/sekoiaio-docker-concentrator/values.yaml
@@ -1,0 +1,107 @@
+image:
+  repository: ghcr.io/sekoia-io/sekoiaio-docker-concentrator
+  # This sets the pull policy for images.
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+intakes: []
+  # - name: Techno1
+  #   protocol: tcp       # tcp | udp | tls
+  #   port: 20516
+  #   intake_key: INTAKE_KEY_FOR_TECHNO_1
+  #   entrypoint: techno1 # optional, used with ingressRoute.enabled (defaults to intake name)
+
+# disk_space is used as DISK_SPACE env var only when persistence is disabled (emptyDir).
+# When persistence is enabled, DISK_SPACE is inferred from persistence.size.
+disk_space: "32g"
+memory_messages: 100000
+region: "FRA1"
+endpoint: ""       # custom intake endpoint, required when region is "other"
+relp_output: false # use RELP protocol instead of TCP for output
+
+persistence:
+  enabled: false
+  # storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 32Gi
+  annotations: {}
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account.
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: LoadBalancer  # LoadBalancer | NodePort | ClusterIP
+  annotations: {}
+
+# When enabled, creates one IngressRouteTCP (tcp/tls) or IngressRouteUDP (udp) per intake.
+# Requires Traefik CRD: traefik.io/v1alpha1 or traefik.containo.us/v1alpha1.
+# Set service.type: ClusterIP to disable direct port exposure alongside Traefik routing.
+# Each intake's Traefik entrypoint defaults to its name; override with the intake's entrypoint field.
+ingressRoute:
+  enabled: false
+
+replicaCount: 1
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  exec:
+    command: ["pgrep", "-x", "rsyslogd"]
+  initialDelaySeconds: 10
+  periodSeconds: 30
+
+readinessProbe:
+  exec:
+    command: ["pgrep", "-x", "rsyslogd"]
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+


### PR DESCRIPTION
Converts the docker-compose setup into a production-ready Helm chart:

- StatefulSet with dynamic ports from intakes (tcp/udp/tls)
- ConfigMap for intakes.yaml generated from values
- Persistence: emptyDir by default, configurable PVC via volumeClaimTemplates
- Environment variables: DISK_SPACE (inferred from PVC size when enabled), MEMORY_MESSAGES, REGION, ENDPOINT, RELP_OUTPUT
- Service: LoadBalancer by default, NodePort (with range validation) or ClusterIP
- ingressRoute: optional Traefik IngressRouteTCP/IngressRouteUDP per intake, with CRD availability check (traefik.io/v1alpha1 or traefik.containo.us/v1alpha1)
- Liveness/readiness probes via pgrep rsyslogd